### PR TITLE
14058 - [API] - Adiciona endpoint para buscar questões via paginação

### DIFF
--- a/examinis/common/schemas/pagination_schema.py
+++ b/examinis/common/schemas/pagination_schema.py
@@ -1,0 +1,24 @@
+from typing import Generic, List, Optional, TypeVar
+
+from pydantic import BaseModel, ConfigDict, conint
+
+
+class PageParams(BaseModel):
+    """ Request query params for paginated API. """
+    page: conint(ge=1) = 1
+    size: conint(ge=1, le=100) = 10
+    order_by: Optional[str] = None
+    order_desc: bool = False
+
+
+T = TypeVar("T")
+
+
+class PagedResponseSchema(BaseModel, Generic[T]):
+    """Response schema for any paged API."""
+    model_config = ConfigDict(arbitrary_types_allowed=True)
+
+    total: int
+    page: int
+    size: int
+    results: List[T]

--- a/examinis/core/ServiceAbstract.py
+++ b/examinis/core/ServiceAbstract.py
@@ -1,5 +1,9 @@
-from typing import Generic, Optional, TypeVar
+from typing import Generic, List, Optional, TypeVar
 
+from examinis.common.schemas.pagination_schema import (
+    PagedResponseSchema,
+    PageParams,
+)
 from examinis.core.RepositoryAbstract import RepositoryAbstract
 from examinis.models import Base
 
@@ -16,5 +20,16 @@ class ServiceAbstract(Generic[T]):
     def get(self, id: int) -> Optional[T]:
         return self.repository.get(id)
 
-    def get_all(self) -> list[T]:
+    def get_all(self) -> List[T]:
         return self.repository.get_all()
+
+    def get_all_paginated(self, params: PageParams) -> PagedResponseSchema[T]:
+        total_items = self.repository.count_all()
+        items = self.repository.get_all_paginated(params)
+
+        return PagedResponseSchema[T](
+            total=total_items,
+            page=params.page,
+            size=params.size,
+            results=items
+        )

--- a/examinis/modules/question/schemas.py
+++ b/examinis/modules/question/schemas.py
@@ -8,7 +8,7 @@ from examinis.modules.subject.schemas import SubjectSchema
 
 
 class QuestionSchema(BaseModel):
-    model_config = ConfigDict(from_attributes=True)
+    model_config = ConfigDict(from_attributes=True, arbitrary_types_allowed=True)
 
     id: int
     text: str

--- a/examinis/modules/question/views.py
+++ b/examinis/modules/question/views.py
@@ -1,5 +1,10 @@
+
 from fastapi import APIRouter, Depends
 
+from examinis.common.schemas.pagination_schema import (
+    PagedResponseSchema,
+    PageParams,
+)
 from examinis.modules.question.schemas import (
     QuestionCreateSchema,
     QuestionSchema,
@@ -10,6 +15,14 @@ router = APIRouter(
     prefix='/question',
     tags=['question'],
 )
+
+
+@router.get("/", response_model=PagedResponseSchema[QuestionSchema])
+def get_questions(
+    params: PageParams = Depends(PageParams),
+    service: QuestionService = Depends(QuestionService),
+):
+    return service.get_all_paginated(params)
 
 
 @router.get('/{question_id}', response_model=QuestionSchema)


### PR DESCRIPTION
## O que esse MR faz?
Implementa método de paginação ao Service Abstract e Schemas de paginação genéricos. Além de utilizá-los no novo endpoint de buscar Question.

## Onde a revisão poderia começar?
common - schemas - pagination_schema.py
core - service_abstract.py

## Como este poderia ser testado manualmente?
Testar o endpoint de Get All do módulo Question. 

## Quais são tickets relevantes?
14058  - https://200.129.79.50:8104/wp/14058